### PR TITLE
Add driving mode switcher

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2019.1.1"
+    id "edu.wpi.first.GradleRIO" version "2019.4.1"
 }
 
 def ROBOT_MAIN_CLASS = "frc.robot.Main"

--- a/src/main/java/frc/robot/Drive/Drive.java
+++ b/src/main/java/frc/robot/Drive/Drive.java
@@ -9,10 +9,8 @@ package frc.robot.Drive;
 
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.command.Command;
-import frc.robot.Constants;
 import frc.robot.Robot;
 import frc.robot.RobotMap;
-import frc.robot.RobotState;
 
 /**
  * The Drive system, utilizing xbox controllers and tank drive to control the robot.
@@ -38,12 +36,9 @@ public class Drive extends Command {
 
   @Override
   protected void execute() {
-    
-    if (RobotState.sensitive) {
-      Robot.drivetrain.TankDrive(Constants.lowGear*xbox.getRawAxis(5), Constants.lowGear*xbox.getRawAxis(1));
-    } else {
-      Robot.drivetrain.TankDrive(Constants.highGear*xbox.getRawAxis(5), Constants.highGear*xbox.getRawAxis(1));
-    }
+
+    Robot.drivetrain.setMode();
+    Robot.drivetrain.TankDrive(xbox.getRawAxis(5), xbox.getRawAxis(1));
     
   }
 

--- a/src/main/java/frc/robot/Drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/Drive/DriveSubsystem.java
@@ -59,7 +59,7 @@ public class DriveSubsystem extends Subsystem {
       roboDrive.tankDrive(Constants.lowGear*leftControl, Constants.lowGear*rightControl, false);
 
     } else {
-      roboDrive.tankDrive(Constants.highGear*leftControl, Constants.lowGear*rightControl, false);
+      roboDrive.tankDrive(Constants.highGear*leftControl, Constants.highGear*rightControl, false);
 
     }
     

--- a/src/main/java/frc/robot/Drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/Drive/DriveSubsystem.java
@@ -8,6 +8,7 @@
 package frc.robot.Drive;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 
 import edu.wpi.first.wpilibj.SpeedControllerGroup;
@@ -16,6 +17,7 @@ import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import frc.robot.Constants;
 import frc.robot.Robot;
 import frc.robot.RobotMap;
+import frc.robot.RobotState;
 
 /**
  * Contains all methods for control of the the drivetrain.
@@ -49,7 +51,47 @@ public class DriveSubsystem extends Subsystem {
    * @see Drive
    */
   public void TankDrive(double leftControl, double rightControl) {
-    roboDrive.tankDrive(leftControl, rightControl, false);
+
+    if (RobotState.fullThrottle) {
+      roboDrive.tankDrive(leftControl, rightControl, false);
+
+    } else if (RobotState.sensitive) {
+      roboDrive.tankDrive(Constants.lowGear*leftControl, Constants.lowGear*rightControl, false);
+
+    } else {
+      roboDrive.tankDrive(Constants.highGear*leftControl, Constants.lowGear*rightControl, false);
+
+    }
+    
+  }
+
+  /**
+   * Switches between offensive and defensive mode when triggered
+   * 
+   * @see SwitchDrivingMode
+   */
+  public void setMode() {
+    if (RobotState.offensiveMode) { // Set motors to offensive mode
+
+      LFrontWheel.setNeutralMode(NeutralMode.Brake);
+      LRearWheel.setNeutralMode(NeutralMode.Brake);
+  
+      RFrontWheel.setNeutralMode(NeutralMode.Brake);
+      RRearWheel.setNeutralMode(NeutralMode.Brake);
+
+      RobotState.fullThrottle = false;
+
+    } else { // Set motors to defensive mode
+
+      LFrontWheel.setNeutralMode(NeutralMode.Coast);
+      LRearWheel.setNeutralMode(NeutralMode.Coast);
+
+      RFrontWheel.setNeutralMode(NeutralMode.Coast);
+      RRearWheel.setNeutralMode(NeutralMode.Coast);
+  
+      RobotState.fullThrottle = true;
+
+    }
   }
 
   /**

--- a/src/main/java/frc/robot/Drive/DriverModeSubsystem.java
+++ b/src/main/java/frc/robot/Drive/DriverModeSubsystem.java
@@ -1,0 +1,37 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.Drive;
+
+import edu.wpi.first.wpilibj.command.Subsystem;
+import frc.robot.RobotState;
+
+/**
+ * Switches robot between a precise and slower offense mode and a fast cruising defense mode
+ */
+public class DriverModeSubsystem extends Subsystem {
+  // Put methods for controlling this subsystem
+  // here. Call these from Commands.
+
+  public void switchMode() {
+
+    if (RobotState.offensiveMode) { // if offensive, change motors to defensive mode
+      RobotState.offensiveMode = false;
+
+    } else { // if defensive, set motors to offensive mode
+      RobotState.offensiveMode = true;
+
+    }
+
+  }
+
+  @Override
+  public void initDefaultCommand() {
+    // Set the default command for a subsystem here.
+    // setDefaultCommand(new MySpecialCommand());
+  }
+}

--- a/src/main/java/frc/robot/Drive/SwitchDrivingMode.java
+++ b/src/main/java/frc/robot/Drive/SwitchDrivingMode.java
@@ -1,0 +1,47 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.Drive;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class SwitchDrivingMode extends Command {
+  public SwitchDrivingMode() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+    requires(Robot.driveModeChanger);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    Robot.driveModeChanger.switchMode();
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return true;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -12,7 +12,7 @@ import edu.wpi.first.wpilibj.buttons.Button;
 import edu.wpi.first.wpilibj.buttons.JoystickButton;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Beak.*;
-import frc.robot.Drive.ChangeSensitivity;
+import frc.robot.Drive.*;
 import frc.robot.VisionProcessing.*;
 import frc.robot.Neck.*;
 import frc.robot.Tail.*;
@@ -66,6 +66,8 @@ public class OI {
 		X.whileHeld(new GoToPanel());
 
 		A.whenPressed(new ChangeSensitivity());
+
+		B.whenPressed(new SwitchDrivingMode());
 
 		start.whenPressed(new MoveTail()); 
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -19,6 +19,7 @@ import frc.robot.Beak.BeakSubsystem;
 //import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 //import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Drive.DriveSubsystem;
+import frc.robot.Drive.DriverModeSubsystem;
 import frc.robot.Drive.SensitivitySubsystem;
 import frc.robot.VisionProcessing.*;
 import frc.robot.Neck.NeckSubsystem;
@@ -40,9 +41,8 @@ public class Robot extends TimedRobot {
   public static BeakSubsystem beak = new BeakSubsystem();
   public static TailSubsystem tail = new TailSubsystem();
   public static SensitivitySubsystem sensitivitySwitcher = new SensitivitySubsystem();
+  public static DriverModeSubsystem driveModeChanger = new DriverModeSubsystem();
   public static OI m_oi;
-
-  
 
   //Command m_autonomousCommand;
   SendableChooser<Command> m_chooser = new SendableChooser<>();

--- a/src/main/java/frc/robot/RobotState.java
+++ b/src/main/java/frc/robot/RobotState.java
@@ -25,4 +25,8 @@ public class RobotState {
 
     public static boolean sensitive = false; 
 
+    public static boolean offensiveMode = true;
+
+    public static boolean fullThrottle = false;
+
 }


### PR DESCRIPTION
This is not an essential feature, but if it works, would be beneficial so drivers could switch to a more effective defense bot when needed, and then switch back to the regular offensive mode